### PR TITLE
Add apt-transport-https as binary package dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.4.1
 
 Package: kt-update
 Architecture: all
-Depends: apt, wget, ${misc:Depends}, bash ( >= 4.4 )
+Depends: apt, wget, ${misc:Depends}, bash ( >= 4.4 ), apt-transport-https
 Recommends: liblockfile-bin, cron | cron-daemon, kt-notify, apt-transport-https, debsums
 Suggests: default-mta | mail-transport-agent
 Description: lightweight distribution management


### PR DESCRIPTION
On a fresh Debian stretch, I got stuck while doing a
switch to another, famous, Debian based distribution.