### PR TITLE
Move apt-transport-https as package dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,8 @@ Standards-Version: 4.4.1
 
 Package: kt-update
 Architecture: all
-Depends: apt, wget, ${misc:Depends}, bash ( >= 4.4 )
-Recommends: liblockfile-bin, cron | cron-daemon, kt-notify, apt-transport-https, debsums
+Depends: apt, wget, ${misc:Depends}, bash ( >= 4.4 ), apt-transport-https
+Recommends: liblockfile-bin, cron | cron-daemon, kt-notify, debsums
 Suggests: default-mta | mail-transport-agent
 Description: lightweight distribution management
  Manage an apt sources.list with some extensions, which can be remotly defined,


### PR DESCRIPTION
On a fresh Debian stretch, I got stuck while doing a
switch to another, famous, Debian based distribution.

I can understand your point that the apt-transport-https is in recommended package and the Stretch policy regarding recommended packages.
However, as I explained, I got stuck while doing a get_conf, meaning apt-transport-https is not a recommended dependency but a real one : the program does not work as expected when this package is not installed.